### PR TITLE
Refactor and enhance Paychangu gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
-## [Unreleased]
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+- Custom error classes for improved error handling (`Paychangu::AuthenticationError`, `Paychangu::InvalidInputError`, `Paychangu::APIError`).
+- Comprehensive unit tests with `webmock` for all public API methods, ensuring better reliability and easier refactoring.
+
+### Changed
+- **Breaking Change:** Switched HTTP client from `Net::HTTP` to `httparty`. While method signatures for public API calls remain the same, underlying HTTP behavior and error handling details have changed. Callers relying on specific `Net::HTTP` exceptions or behaviors might need to adapt.
+- **Breaking Change:** Standard `RuntimeError` exceptions (e.g., for invalid input or API errors) are replaced by more specific custom errors:
+    - `Paychangu::InvalidInputError` for issues like missing secret keys or unsupported currencies.
+    - `Paychangu::AuthenticationError` for 401 API errors.
+    - `Paychangu::InvalidInputError` for 400, 404, 422 API errors.
+    - `Paychangu::APIError` for other API-related errors (e.g., 5xx status codes, connection issues).
+- Refactored internal request processing logic for clarity, leveraging `httparty` for request execution and `handle_response` for centralized error management.
+- Payload generation methods (e.g., `create_link_payload`) now return Ruby Hashes internally, with JSON conversion handled by the HTTP client layer.
+
+### Fixed
+- Ensured consistent error handling and reporting across different API interaction scenarios.
+- Improved test coverage significantly.
 
 ## [0.1.0] - 2023-12-12
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,35 @@ PATH
   remote: .
   specs:
     Paychangu (0.2.4)
+      httparty (~> 0.20)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    bigdecimal (3.2.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    csv (3.3.5)
     diff-lcs (1.5.0)
+    hashdiff (1.2.0)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
+    mini_mime (1.1.5)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    public_suffix (6.0.2)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
@@ -47,6 +64,10 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.5.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin-22
@@ -57,6 +78,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  webmock (~> 3.18)
 
 BUNDLED WITH
    2.4.22

--- a/lib/paychangu.rb
+++ b/lib/paychangu.rb
@@ -1,19 +1,26 @@
 # frozen_string_literal: true
 
-require "uri"
-require "json"
-require "net/http"
 require "securerandom"
+require 'httparty'
 
 require_relative "paychangu/version"
+require_relative "paychangu/errors"
 
+# Provides classes and methods for interacting with the PayChangu API.
 module Paychangu
-  # Main Payemnt Class
+  # Main class for interacting with the PayChangu Payment API.
+  # It handles creating payment links, managing virtual cards, airtime purchases, and verifying payments.
   class Payment
-    API_URL = URI("https://api.paychangu.com/").freeze
+    include HTTParty # Include HTTParty module
+    base_uri 'https://api.paychangu.com' # Set base URI for all requests
+    format :json # Default format for requests and responses
+
+    # Supported currencies for general payments.
     SUPPORTED_CURRENCIES = %w[MWK NGN ZAR GBP USD ZMW].freeze
+    # Supported currencies for virtual card operations.
     SUPPORTED_CARD_CURRENCIES = %w[USD].freeze
 
+    # API endpoint paths used by the client.
     API_ENDPOINTS = {
       payment: "payment",
       create_card: "virtual_card/create",
@@ -24,6 +31,7 @@ module Paychangu
       verify_payment: "verify-payment"
     }.freeze
 
+    # HTTP request methods supported.
     REQUEST_METHODS = {
       post: "POST",
       get: "GET",
@@ -33,42 +41,137 @@ module Paychangu
 
     def initialize(secret_key)
       @secret = paychangu_secret(secret_key)
+      self.class.headers "Authorization" => "Bearer #{@secret}"
+      self.class.headers "Accept" => "application/json"
+      # Content-Type will be set per request if there's a body
     end
 
+    # Initializes a new Payment client.
+    # @param secret_key [String] Your PayChangu API secret key.
+    # @raise [Paychangu::InvalidInputError] if the secret_key is nil or empty.
+    def initialize(secret_key)
+      @secret = paychangu_secret(secret_key)
+      self.class.headers "Authorization" => "Bearer #{@secret}"
+      self.class.headers "Accept" => "application/json"
+      # Content-Type will be set per request if there's a body
+    end
+
+    # Creates a payment link.
+    #
+    # @param data [Hash] The payment data.
+    # @option data [Float, Integer] :amount The amount for the payment.
+    # @option data [String] :currency The currency code (e.g., "MWK", "USD"). See {SUPPORTED_CURRENCIES}.
+    # @option data [String] :email The customer's email address.
+    # @option data [String] :first_name The customer's first name.
+    # @option data [String] :last_name The customer's last name.
+    # @option data [String] :callback_url The URL to send a POST request to upon payment completion.
+    # @option data [String] :return_url The URL to redirect the user to after payment.
+    # @option data [String] :tx_ref (optional) Unique transaction reference. Auto-generated if not provided.
+    # @option data [String] :title (optional) The title for the payment page customization.
+    # @option data [String] :description (optional) The description for the payment page customization.
+    # @option data [String] :logo (optional) URL to a logo for payment page customization.
+    # @return [Hash] The API response containing the payment link details.
+    # @raise [Paychangu::InvalidInputError] if required parameters are missing or invalid (e.g., unsupported currency).
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def create_payment_link(data = {})
+      required_keys = %i[amount currency email first_name last_name callback_url return_url]
+      validate_presence_of(data, required_keys)
+
       payload = create_link_payload(data)
 
       process_request(payload, API_ENDPOINTS[:payment], REQUEST_METHODS[:post])
     end
 
+    # Creates a virtual card.
+    #
+    # @param data [Hash] The virtual card data.
+    # @option data [Float, Integer] :amount The initial amount to fund the card.
+    # @option data [String] :currency The currency code (e.g., "USD"). See {SUPPORTED_CARD_CURRENCIES}.
+    # @option data [String] :first_name The cardholder's first name.
+    # @option data [String] :last_name The cardholder's last name.
+    # @option data [String] :callback_url The URL to send a POST request to upon card event.
+    # @return [Hash] The API response containing the virtual card details.
+    # @raise [Paychangu::InvalidInputError] if required parameters are missing or invalid.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def create_virtual_card(data = {})
+      required_keys = %i[amount currency first_name last_name callback_url]
+      validate_presence_of(data, required_keys)
       payload = create_card_payload(data)
 
       process_request(payload, API_ENDPOINTS[:create_card], REQUEST_METHODS[:post])
     end
 
+    # Funds a virtual card.
+    #
+    # @param data [Hash] The funding data.
+    # @option data [Float, Integer] :amount The amount to fund.
+    # @option data [String] :card_hash The hash of the card to fund.
+    # @return [Hash] The API response confirming the funding.
+    # @raise [Paychangu::InvalidInputError] if required parameters are missing.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def fund_card(data = {})
+      required_keys = %i[amount card_hash]
+      validate_presence_of(data, required_keys)
       payload = fund_card_payload(data)
 
       process_request(payload, API_ENDPOINTS[:fund_card], REQUEST_METHODS[:post])
     end
 
+    # Withdraws funds from a virtual card.
+    #
+    # @param data [Hash] The withdrawal data.
+    # @option data [Float, Integer] :amount The amount to withdraw.
+    # @option data [String] :card_hash The hash of the card to withdraw from.
+    # @return [Hash] The API response confirming the withdrawal.
+    # @raise [Paychangu::InvalidInputError] if required parameters are missing.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def withdraw_card_funds(data = {})
+      required_keys = %i[amount card_hash]
+      validate_presence_of(data, required_keys)
       payload = withdraw_card_funds_payload(data)
 
       process_request(payload, API_ENDPOINTS[:withdraw], REQUEST_METHODS[:post])
     end
 
+    # Retrieves the list of available airtime operators.
+    #
+    # @return [Hash] The API response containing the list of operators.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def airtime_operators
       process_request(nil, API_ENDPOINTS[:get_operators], REQUEST_METHODS[:get])
     end
 
+    # Makes an airtime payment.
+    #
+    # @param data [Hash] The airtime payment data.
+    # @option data [String] :operator The operator code.
+    # @option data [Float, Integer] :amount The amount for the airtime purchase.
+    # @option data [String] :phone The phone number to receive the airtime.
+    # @option data [String] :callback_url The URL to send a POST request to upon completion.
+    # @return [Hash] The API response confirming the airtime payment.
+    # @raise [Paychangu::InvalidInputError] if required parameters are missing.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors.
     def airtime_payment(data = {})
+      required_keys = %i[operator amount phone callback_url]
+      validate_presence_of(data, required_keys)
       payload = create_airtime_payment_payload(data)
 
       process_request(payload, API_ENDPOINTS[:airtime_payment], REQUEST_METHODS[:post])
     end
 
+    # Verifies a payment transaction.
+    #
+    # @param data [Hash] The verification data.
+    # @option data [String] :tx_ref The transaction reference to verify.
+    # @return [Hash] The API response containing the payment verification status.
+    # @raise [Paychangu::AuthenticationError] if authentication fails.
+    # @raise [Paychangu::APIError] for other API-related errors (e.g., if transaction not found, specific errors like NotFoundError may be raised).
     def verify_payment(data = {})
       process_request(nil, "#{API_ENDPOINTS[:verify_payment]}/#{data[:tx_ref]}", REQUEST_METHODS[:get])
     end
@@ -76,20 +179,17 @@ module Paychangu
     private
 
     def paychangu_secret(secret_key)
-      raise "Secret key not provided!" unless secret_key
-
+      raise Paychangu::InvalidInputError, "Secret key not provided!" if secret_key.nil? || secret_key.to_s.empty?
       secret_key
     end
 
     def get_supported_currencies(currency)
-      raise "#{currency} currency not supported!" unless SUPPORTED_CURRENCIES.include?(currency)
-
+      raise Paychangu::InvalidInputError, "#{currency} currency not supported!" unless SUPPORTED_CURRENCIES.include?(currency)
       currency
     end
 
     def get_card_supported_currencies(currency)
-      raise "#{currency} currency not supported" unless SUPPORTED_CARD_CURRENCIES.include?(currency)
-
+      raise Paychangu::InvalidInputError, "#{currency} currency not supported for cards!" unless SUPPORTED_CARD_CURRENCIES.include?(currency)
       currency
     end
 
@@ -103,9 +203,9 @@ module Paychangu
         callback_url: data[:callback_url],
         return_url: data[:return_url],
         tx_ref: data[:tx_ref] || SecureRandom.hex(10),
-        customization: customization(data),
+        customization: customization(data), # customization already returns a Hash
         logo: data[:logo]
-      }.to_json
+      } # Remove .to_json
     end
 
     def create_card_payload(data)
@@ -115,28 +215,28 @@ module Paychangu
         first_name: data[:first_name],
         last_name: data[:last_name],
         callback_url: data[:callback_url]
-      }.to_json
+      } # Remove .to_json
     end
 
     def fund_card_payload(data)
       {
         amount: data[:amount],
         card_hash: data[:card_hash]
-      }.to_json
+      } # Remove .to_json
     end
 
     def withdraw_card_funds_payload(data)
       {
         amount: data[:amount],
         card_hash: data[:card_hash]
-      }.to_json
+      } # Remove .to_json
     end
 
     def customization(data)
       {
         title: data[:title],
         description: data[:description]
-      }
+      } # This is fine, returns a Hash
     end
 
     def create_airtime_payment_payload(data)
@@ -145,41 +245,92 @@ module Paychangu
         amount: data[:amount],
         phone: data[:phone],
         callback_url: data[:callback_url]
-      }.to_json
+      } # Remove .to_json
     end
 
-    def process_request(payload, path, method)
-      http = Net::HTTP.new(API_URL.host, API_URL.port)
-      http.use_ssl = true
-
-      case method
-      when "POST"
-        request = Net::HTTP::Post.new("#{API_URL}#{path}")
-        request["accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@secret}"
-        request["content-type"] = "application/json"
-        request.body = payload
-      when "GET"
-        request = Net::HTTP::Get.new("#{API_URL}#{path}")
-        request["accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@secret}"
-        request["content-type"] = "application/json"
-      when "PUT"
-        request = Net::HTTP::Put.new("#{API_URL}#{path}")
-        request["accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@secret}"
-        request["content-type"] = "application/json"
-        request.body = payload
-      when "DELETE"
-        request = Net::HTTP::Delete.new("#{API_URL}#{path}")
-        request["accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@secret}"
-        request["content-type"] = "application/json"
-        request.body = payload
+    def validate_presence_of(data, required_keys)
+      required_keys.each do |key|
+        if data[key].nil? || (data[key].is_a?(String) && data[key].strip.empty?)
+          raise Paychangu::InvalidInputError, "Missing required parameter: #{key}"
+        end
       end
+    end
 
-      response = http.request(request)
-      JSON.parse(response.body)
+    def process_request(payload, path, method_verb)
+      options = { headers: {} } # Initialize options with headers hash
+
+      if payload && (method_verb == REQUEST_METHODS[:post] || method_verb == REQUEST_METHODS[:put])
+        options[:body] = payload.to_json
+        options[:headers]['Content-Type'] = 'application/json'
+      end
+      # No specific Content-Type logic for GET/DELETE here, HTTParty handles it.
+
+      begin
+        response = case method_verb
+                   when REQUEST_METHODS[:post]
+                     self.class.post("/#{path}", options)
+                   when REQUEST_METHODS[:get]
+                     # If 'payload' were to contain query parameters: options[:query] = payload
+                     self.class.get("/#{path}", options)
+                   when REQUEST_METHODS[:put]
+                     self.class.put("/#{path}", options)
+                   when REQUEST_METHODS[:delete]
+                     # If 'payload' were to contain query parameters: options[:query] = payload
+                     self.class.delete("/#{path}", options)
+                   else
+                     raise Paychangu::InvalidInputError, "Unsupported HTTP method: #{method_verb}"
+                   end
+
+        handle_response(response)
+      rescue Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+        raise Paychangu::APIError, "Connection error: #{e.message}"
+      end
+    end
+
+    def handle_response(response)
+      parsed_response = response.parsed_response
+      status_code = response.code
+
+      # Log request and response for debugging (optional, consider a logger)
+      # puts "PayChangu API Request: #{response.request.http_method} #{response.request.uri}"
+      # puts "PayChangu API Response Status: #{status_code}"
+      # puts "PayChangu API Response Body: #{parsed_response.inspect}"
+
+
+      case status_code
+      when 200..299
+        parsed_response
+      when 401
+        raise Paychangu::AuthenticationError.new(
+          (parsed_response&.is_a?(Hash) && parsed_response['message']) || "Authentication failed",
+          response_body: parsed_response.to_s,
+          status_code: status_code
+        )
+      when 400
+        raise Paychangu::BadRequestError.new(
+          (parsed_response&.is_a?(Hash) && parsed_response['message']) || "Bad request",
+          response_body: parsed_response.to_s,
+          status_code: status_code
+        )
+      when 404
+        raise Paychangu::NotFoundError.new(
+          (parsed_response&.is_a?(Hash) && parsed_response['message']) || "Resource not found",
+          response_body: parsed_response.to_s,
+          status_code: status_code
+        )
+      when 422
+        raise Paychangu::UnprocessableEntityError.new(
+          (parsed_response&.is_a?(Hash) && parsed_response['message']) || "Unprocessable entity",
+          response_body: parsed_response.to_s,
+          status_code: status_code
+        )
+      else # 5xx or other 4xx
+        raise Paychangu::APIError.new(
+          (parsed_response&.is_a?(Hash) && parsed_response['message']) || "API request failed",
+          response_body: parsed_response.to_s,
+          status_code: status_code
+        )
+      end
     end
   end
 end

--- a/lib/paychangu/errors.rb
+++ b/lib/paychangu/errors.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Paychangu
+  class Error < StandardError; end # General base error
+  class APIError < Error # Base for errors from API responses
+    def initialize(message = nil, response_body: nil, status_code: nil)
+      @response_body = response_body
+      @status_code = status_code
+      super(message)
+    end
+
+    def to_s
+      base_message = super
+      details = []
+      details << "Status: #{@status_code}" if @status_code
+      details << "Response: #{@response_body}" if @response_body && !@response_body.empty?
+      "#{base_message}#{" (#{details.join(', ')})" unless details.empty?}"
+    end
+  end
+  class AuthenticationError < APIError; end # Inherits APIError's initialize
+  class InvalidInputError < APIError; end   # Inherits APIError's initialize
+  class NotFoundError < APIError; end # For 404 errors
+  class BadRequestError < APIError; end # For 400 errors
+  class UnprocessableEntityError < APIError; end # For 422 errors
+end

--- a/paychangu.gemspec
+++ b/paychangu.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "httparty", "~> 0.20"
+  spec.add_development_dependency "webmock", "~> 3.18"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/paychangu_spec.rb
+++ b/spec/paychangu_spec.rb
@@ -1,62 +1,403 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "paychangu"
+# require "paychangu" # spec_helper already requires it
+require 'paychangu/errors' # Required for explicit error type checking
 
 RSpec.describe Paychangu::Payment do
-  let(:secret_key) { "Test" }
+  let(:secret_key) { "test_secret_key" }
+  let(:base_api_url) { "https://api.paychangu.com" }
+  let(:payment) { described_class.new(secret_key) }
+
+  # Helper to stub requests easily
+  def stub_paychangu_request(method, path, request_body: nil, response_body: {}, status: 200)
+    expected_headers = {
+      'Accept'=>'application/json',
+      'Authorization'=>"Bearer #{secret_key}"
+    }
+    # Add Content-Type only if there's a request body AND it's a POST/PUT (Ruby symbols for methods)
+    # HTTParty default methods are get, post, put, delete, patch, head, options
+    if request_body && (method == :post || method == :put)
+      expected_headers['Content-Type'] = 'application/json'
+    end
+
+    stub_request(method, "#{base_api_url}/#{path}")
+      .with(
+        headers: expected_headers,
+        body: request_body
+      )
+      .to_return(status: status, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
 
   describe "#initialize" do
-    it "has a version number" do
+    it "has a version number" do # This test might be better in a general gem spec
       expect(Paychangu::VERSION).not_to be nil
     end
+
     it "initializes the Payment class with a secret key" do
-      payment = described_class.new(secret_key)
       expect(payment.instance_variable_get(:@secret)).to eq(secret_key)
     end
 
-    it "raises an error if no secret key is provided" do
-      expect { described_class.new(nil) }.to raise_error(RuntimeError, "Secret key not provided!")
+    it "raises Paychangu::InvalidInputError if no secret key is provided" do
+      expect { described_class.new(nil) }.to raise_error(Paychangu::InvalidInputError, "Secret key not provided!")
+      expect { described_class.new('') }.to raise_error(Paychangu::InvalidInputError, "Secret key not provided!")
     end
   end
 
   describe "#create_payment_link" do
-    it "creates a payment link" do
-      payment = described_class.new(secret_key)
-      data = {
-        amount: 100,
-        currency: "USD",
-        email: "test@example.com",
-        first_name: "John",
-        last_name: "Doe",
-        callback_url: "https://example.com/callback",
-        return_url: "https://example.com/return",
-        tx_ref: "txn_123456",
-        title: "Test Payment",
-        description: "This is a test payment",
-        logo: "https://example.com/logo.png"
+    let(:valid_payload) do
+      {
+        amount: 100, currency: "MWK", email: "test@example.com", first_name: "John",
+        last_name: "Doe", callback_url: "cb_url", return_url: "ret_url",
+        tx_ref: "test_tx_ref", title: "Test Title", description: "Test Desc", logo: "logo.png"
       }
-
-      expect { payment.create_payment_link(data) }.not_to raise_error
+    end
+    let(:customization_data) { { title: valid_payload[:title], description: valid_payload[:description] } }
+    let(:expected_request_body) do
+        valid_payload.except(:title, :description).merge(customization: customization_data)
     end
 
-    it "raises an error if the payment currency is not valid" do
-      payment = described_class.new(secret_key)
-      data = {
-        amount: 100,
-        currency: "USD1",
-        email: "test@example.com",
-        first_name: "John",
-        last_name: "Doe",
-        callback_url: "https://example.com/callback",
-        return_url: "https://example.com/return",
-        tx_ref: "txn_123456",
-        title: "Test Payment",
-        description: "This is a test payment",
-        logo: "https://example.com/logo.png"
-      }
+    it "creates a payment link successfully" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:payment],
+                             request_body: expected_request_body,
+                             response_body: { status: "success", data: { link: "payment_link" } })
 
-      expect { payment.create_payment_link(data) }.to raise_error(RuntimeError, "USD1 currency not supported!")
+      response = payment.create_payment_link(valid_payload)
+      expect(response["status"]).to eq("success")
+      expect(response["data"]["link"]).to eq("payment_link")
+    end
+
+    it "raises Paychangu::InvalidInputError for unsupported currency" do
+      invalid_payload = valid_payload.merge(currency: "XYZ")
+      expect { payment.create_payment_link(invalid_payload) }
+        .to raise_error(Paychangu::InvalidInputError, "XYZ currency not supported!")
+    end
+
+    it "raises Paychangu::APIError for API failures" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:payment],
+                             request_body: expected_request_body,
+                             response_body: { message: "Internal server error" }, status: 500)
+      expect { payment.create_payment_link(valid_payload) }
+        .to raise_error(Paychangu::APIError, /Internal server error.*Status: 500/)
+    end
+
+     it "uses a new tx_ref if none is provided" do
+      payload_without_tx_ref = valid_payload.except(:tx_ref)
+      allow(SecureRandom).to receive(:hex).with(10).and_return("mocked_tx_ref")
+      expected_body_with_mocked_tx_ref = payload_without_tx_ref.except(:title, :description)
+                                          .merge(customization: customization_data, tx_ref: "mocked_tx_ref")
+
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:payment],
+                             request_body: expected_body_with_mocked_tx_ref,
+                             response_body: { status: "success" })
+      payment.create_payment_link(payload_without_tx_ref)
+    end
+
+    it "creates a payment link successfully with a different valid currency (NGN)" do
+      ngn_payload = valid_payload.merge(currency: "NGN")
+      expected_ngn_request_body = expected_request_body.merge(currency: "NGN")
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:payment],
+                             request_body: expected_ngn_request_body,
+                             response_body: { status: "success", data: { link: "payment_link_ngn" } })
+
+      response = payment.create_payment_link(ngn_payload)
+      expect(response["status"]).to eq("success")
+      expect(response["data"]["link"]).to eq("payment_link_ngn")
+    end
+
+    it "creates a payment link successfully when optional parameters (title, description, logo) are not provided" do
+      payload_without_optionals = valid_payload.except(:title, :description, :logo)
+      # Customization will be an empty hash or have nils if not provided.
+      # The create_link_payload method creates customization like:
+      # { title: data[:title], description: data[:description] }
+      # So, if title and description are not in data, customization becomes { title: nil, description: nil }
+      expected_customization_without_optionals = { title: nil, description: nil }
+      expected_request_body_without_optionals = payload_without_optionals
+                                                  .except(:title, :description) # These were already removed for base expected_request_body
+                                                  .merge(customization: expected_customization_without_optionals, logo: nil)
+
+
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:payment],
+                             request_body: expected_request_body_without_optionals,
+                             response_body: { status: "success" })
+      payment.create_payment_link(payload_without_optionals)
+    end
+
+    context "input validations" do
+      let(:base_payload) do
+        {
+          amount: 100, currency: "MWK", email: "test@example.com", first_name: "John",
+          last_name: "Doe", callback_url: "cb_url", return_url: "ret_url",
+          tx_ref: "test_tx_ref", title: "Test Title", description: "Test Desc", logo: "logo.png"
+        }
+      end
+
+      %i[amount currency email first_name last_name callback_url return_url].each do |required_key|
+        it "raises an error if #{required_key} is missing" do
+          payload = base_payload.dup
+          payload.delete(required_key) # Test for key completely missing
+          expect { payment.create_payment_link(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        it "raises an error if #{required_key} is nil" do
+          payload = base_payload.merge(required_key => nil) # Test for key present but nil
+          expect { payment.create_payment_link(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        # Optional: Test for empty string if applicable to your validation logic for string fields
+        if %i[email first_name last_name callback_url return_url].include?(required_key)
+          it "raises an error if #{required_key} is an empty string" do
+            payload = base_payload.merge(required_key => "") # Test for key present but empty string
+            expect { payment.create_payment_link(payload) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+
+            payload_with_whitespace = base_payload.merge(required_key => "   ") # Test for key present but whitespace string
+            expect { payment.create_payment_link(payload_with_whitespace) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#create_virtual_card" do
+    let(:valid_payload) { { amount: 50, currency: "USD", first_name: "Jane", last_name: "Doe", callback_url: "cb_url" } }
+
+    it "creates a virtual card successfully with USD currency" do # Explicitly testing valid card currency
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:create_card],
+                             request_body: valid_payload, # valid_payload already uses USD
+                             response_body: { status: "success", data: { card_id: "card_123_usd" } })
+      response = payment.create_virtual_card(valid_payload)
+      expect(response["status"]).to eq("success")
+      expect(response["data"]["card_id"]).to eq("card_123_usd")
+    end
+
+    it "raises Paychangu::InvalidInputError for unsupported card currency" do
+      invalid_payload = valid_payload.merge(currency: "MWK")
+      expect { payment.create_virtual_card(invalid_payload) }
+        .to raise_error(Paychangu::InvalidInputError, "MWK currency not supported for cards!")
+    end
+
+    it "raises Paychangu::BadRequestError for API failures with 400 status" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:create_card],
+                             request_body: valid_payload,
+                             response_body: { message: "Card creation failed" }, status: 400)
+      expect { payment.create_virtual_card(valid_payload) }
+        .to raise_error(Paychangu::BadRequestError, /Card creation failed.*Status: 400/)
+    end
+
+    context "input validations" do
+      let(:base_payload) { { amount: 50, currency: "USD", first_name: "Jane", last_name: "Doe", callback_url: "cb_url" } }
+
+      %i[amount currency first_name last_name callback_url].each do |required_key|
+        it "raises an error if #{required_key} is missing" do
+          payload = base_payload.dup
+          payload.delete(required_key)
+          expect { payment.create_virtual_card(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        it "raises an error if #{required_key} is nil" do
+          payload = base_payload.merge(required_key => nil)
+          expect { payment.create_virtual_card(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        if %i[currency first_name last_name callback_url].include?(required_key)
+          it "raises an error if #{required_key} is an empty string" do
+            payload = base_payload.merge(required_key => "")
+            expect { payment.create_virtual_card(payload) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+            payload_ws = base_payload.merge(required_key => "   ")
+            expect { payment.create_virtual_card(payload_ws) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#fund_card" do
+    let(:valid_payload) { { amount: 100, card_hash: "hash123" } }
+    it "funds a card successfully" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:fund_card],
+                             request_body: valid_payload,
+                             response_body: { status: "success" })
+      expect(payment.fund_card(valid_payload)["status"]).to eq("success")
+    end
+     it "raises Paychangu::APIError for API failures" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:fund_card],
+                             request_body: valid_payload,
+                             response_body: { message: "Funding failed" }, status: 500)
+      expect { payment.fund_card(valid_payload) }
+        .to raise_error(Paychangu::APIError, /Funding failed.*Status: 500/)
+    end
+
+    context "input validations" do
+      let(:base_payload) { { amount: 100, card_hash: "hash123" } }
+
+      %i[amount card_hash].each do |required_key|
+        it "raises an error if #{required_key} is missing" do
+          payload = base_payload.dup
+          payload.delete(required_key)
+          expect { payment.fund_card(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        it "raises an error if #{required_key} is nil" do
+          payload = base_payload.merge(required_key => nil)
+          expect { payment.fund_card(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        if %i[card_hash].include?(required_key) # card_hash is a string
+          it "raises an error if #{required_key} is an empty string" do
+            payload = base_payload.merge(required_key => "")
+            expect { payment.fund_card(payload) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+            payload_ws = base_payload.merge(required_key => "   ")
+            expect { payment.fund_card(payload_ws) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#withdraw_card_funds" do
+    let(:valid_payload) { { amount: 50, card_hash: "hash123" } }
+    it "withdraws card funds successfully" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:withdraw],
+                             request_body: valid_payload,
+                             response_body: { status: "success" })
+      expect(payment.withdraw_card_funds(valid_payload)["status"]).to eq("success")
+    end
+    it "raises Paychangu::APIError for API failures" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:withdraw],
+                             request_body: valid_payload,
+                             response_body: { message: "Withdrawal failed" }, status: 500)
+      expect { payment.withdraw_card_funds(valid_payload) }
+        .to raise_error(Paychangu::APIError, /Withdrawal failed.*Status: 500/)
+    end
+
+    context "input validations" do
+      let(:base_payload) { { amount: 50, card_hash: "hash123" } }
+
+      %i[amount card_hash].each do |required_key|
+        it "raises an error if #{required_key} is missing" do
+          payload = base_payload.dup
+          payload.delete(required_key)
+          expect { payment.withdraw_card_funds(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        it "raises an error if #{required_key} is nil" do
+          payload = base_payload.merge(required_key => nil)
+          expect { payment.withdraw_card_funds(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        if %i[card_hash].include?(required_key) # card_hash is a string
+          it "raises an error if #{required_key} is an empty string" do
+            payload = base_payload.merge(required_key => "")
+            expect { payment.withdraw_card_funds(payload) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+            payload_ws = base_payload.merge(required_key => "   ")
+            expect { payment.withdraw_card_funds(payload_ws) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#airtime_operators" do
+    it "gets airtime operators successfully" do
+      stub_paychangu_request(:get, Paychangu::Payment::API_ENDPOINTS[:get_operators],
+                             response_body: { status: "success", data: ["Op1", "Op2"] })
+      response = payment.airtime_operators
+      expect(response["status"]).to eq("success")
+      expect(response["data"]).to include("Op1")
+    end
+     it "raises Paychangu::APIError for API failures" do
+      stub_paychangu_request(:get, Paychangu::Payment::API_ENDPOINTS[:get_operators],
+                             response_body: { message: "Failed to fetch" }, status: 503)
+      expect { payment.airtime_operators }
+        .to raise_error(Paychangu::APIError, /Failed to fetch.*Status: 503/)
+    end
+  end
+
+  describe "#airtime_payment" do
+    let(:valid_payload) { { operator: "Op1", amount: 10, phone: "12345", callback_url: "cb_url" } }
+    it "makes an airtime payment successfully" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:airtime_payment],
+                             request_body: valid_payload,
+                             response_body: { status: "success" })
+      expect(payment.airtime_payment(valid_payload)["status"]).to eq("success")
+    end
+    it "raises Paychangu::BadRequestError for API failures with 400 status" do
+      stub_paychangu_request(:post, Paychangu::Payment::API_ENDPOINTS[:airtime_payment],
+                             request_body: valid_payload,
+                             response_body: { message: "Airtime purchase failed" }, status: 400)
+      expect { payment.airtime_payment(valid_payload) }
+        .to raise_error(Paychangu::BadRequestError, /Airtime purchase failed.*Status: 400/)
+    end
+
+    context "input validations" do
+      let(:base_payload) { { operator: "Op1", amount: 10, phone: "12345", callback_url: "cb_url" } }
+
+      %i[operator amount phone callback_url].each do |required_key|
+        it "raises an error if #{required_key} is missing" do
+          payload = base_payload.dup
+          payload.delete(required_key)
+          expect { payment.airtime_payment(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        it "raises an error if #{required_key} is nil" do
+          payload = base_payload.merge(required_key => nil)
+          expect { payment.airtime_payment(payload) }
+            .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+        end
+
+        if %i[operator phone callback_url].include?(required_key) # String fields
+          it "raises an error if #{required_key} is an empty string" do
+            payload = base_payload.merge(required_key => "")
+            expect { payment.airtime_payment(payload) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+            payload_ws = base_payload.merge(required_key => "   ")
+            expect { payment.airtime_payment(payload_ws) }
+              .to raise_error(Paychangu::InvalidInputError, "Missing required parameter: #{required_key}")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#verify_payment" do
+    let(:tx_ref) { "ref123" }
+    it "verifies a payment successfully" do
+      stub_paychangu_request(:get, "#{Paychangu::Payment::API_ENDPOINTS[:verify_payment]}/#{tx_ref}",
+                             response_body: { status: "success", data: { state: "PAID" } })
+      response = payment.verify_payment(tx_ref: tx_ref)
+      expect(response["status"]).to eq("success")
+      expect(response["data"]["state"]).to eq("PAID")
+    end
+
+    it "raises Paychangu::NotFoundError for API failures with 404 status" do
+      stub_paychangu_request(:get, "#{Paychangu::Payment::API_ENDPOINTS[:verify_payment]}/#{tx_ref}",
+                             response_body: { message: "Verification failed" }, status: 404)
+      expect { payment.verify_payment(tx_ref: tx_ref) }
+        .to raise_error(Paychangu::NotFoundError, /Verification failed.*Status: 404/)
+    end
+
+    it "raises Paychangu::AuthenticationError for 401 status" do
+      stub_paychangu_request(:get, "#{Paychangu::Payment::API_ENDPOINTS[:verify_payment]}/#{tx_ref}",
+                             response_body: { message: "Invalid token" }, status: 401)
+      expect { payment.verify_payment(tx_ref: tx_ref) }
+        .to raise_error(Paychangu::AuthenticationError, /Invalid token.*Status: 401/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require "paychangu"
+require 'webmock/rspec'
 
 RSpec.configure do |config|
+  WebMock.disable_net_connect!(allow_localhost: true)
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
This commit introduces several improvements to the Paychangu Ruby gem:

- **Error Handling:** I refactored error handling to use more specific error classes (BadRequestError, NotFoundError, UnprocessableEntityError) inheriting from APIError. This provides better granularity for API error responses.

- **Input Validation:** I implemented robust input validation for all public methods accepting data hashes. A new `validate_presence_of` helper ensures that required parameters are present and not empty, raising an InvalidInputError if checks fail.

- **Code Refactoring:**
    - I streamlined header management in `process_request` by relying on HTTParty's class-level default headers for Authorization and Accept.
    - Content-Type is now only set for POST/PUT requests that include a payload.
    - I confirmed that explicit `.to_json` calls on payloads were not necessary and HTTParty handles serialization.

- **Test Coverage:** I improved test coverage significantly (from an initial count to 77 tests). I added tests for:
    - New specific error types.
    - Input validation scenarios (missing/invalid parameters).
    - Different valid currency usages.
    - Correct handling of optional parameters in payloads.

- **Documentation:** I added comprehensive YARD-style inline documentation for all public methods, the main class, module, and relevant constants to improve your experience and maintainability.

These changes make the gem more robust, easier to use, and better documented.